### PR TITLE
Handle case where entry does not have 'altText'

### DIFF
--- a/__mocks__/mockArticle.ts
+++ b/__mocks__/mockArticle.ts
@@ -216,7 +216,6 @@ export default {
     _type: 'slug',
     current: 'fluctuations-in-energy-readings'
   },
-  altText: 'Some visually-descriptive text',
   publishedDate: '2019-08-08T07:00:00.000Z',
   title: 'Fluctuations in energy readings'
 }

--- a/src/utils/getMedia.ts
+++ b/src/utils/getMedia.ts
@@ -13,7 +13,7 @@ export default function resolveMedia(featuredMedia: FeaturedMedia | undefined) {
     type: media.mimeType,
     src: media.url,
     thumbnailSrc: media.url,
-    altText: featuredMedia.altText
+    altText: featuredMedia.altText || ''
   })
 
   const mergedMedia = { ...featuredMedia, ...mappedMedia }

--- a/test/mapSanityEntry.test.ts
+++ b/test/mapSanityEntry.test.ts
@@ -1,17 +1,33 @@
 import mapSanityEntry from '../src/utils/mapSanityEntry'
 import mockArticle from '../__mocks__/mockArticle'
 import mockBlog from '../__mocks__/mockBlog'
+import mockHeroBanner from '../__mocks__/mockHeroBanner'
 
 describe('mapSanityEntry', () => {
-  it('creates an object of type Content', () => {
-    const item = mapSanityEntry(mockArticle)
+  it('creates an object of type heroBanner', () => {
+    const item = mapSanityEntry(mockHeroBanner)
 
     expect(item.cmsSyncSourceContentId).toBe(
-      'drafts.2aa6f3c2-04f3-4d3c-96c9-e6d6ddabe0a7'
+      'drafts.445cf20e-82d9-43ee-876d-c0563629ccc6'
     )
-    expect(item.title).toBe('Fluctuations in energy readings')
-    expect(item.handle).toBe('fluctuations-in-energy-readings')
+    expect(item.title).toBe('The future of furniture')
+    expect(item.handle).toBe('the-future-of-furniture')
     expect(item.cmsSyncSource).toBe('sanity')
+    expect(item.type).toBe('heroBanner')
+    expect(item.featuredMedia).toStrictEqual({
+      id: 'image-57db6970e0fe735f6ef2d45d1367a92f1afed9a9-1200x675-jpg',
+      type: 'image/jpeg',
+      src:
+        'https://cdn.sanity.io/images/ciu31kkt/production/57db6970e0fe735f6ef2d45d1367a92f1afed9a9-1200x675.jpg',
+      thumbnailSrc:
+        'https://cdn.sanity.io/images/ciu31kkt/production/57db6970e0fe735f6ef2d45d1367a92f1afed9a9-1200x675.jpg',
+      altText: 'Some visually-descriptive text'
+    })
+  })
+
+  it('creates an object of type article that has featuredMedia with altText empty string', () => {
+    const item = mapSanityEntry(mockArticle)
+
     expect(item.type).toBe('article')
     expect(item.featuredMedia).toStrictEqual({
       id: 'image-ca4484084823a781e6436bb5b7ab6c8164ab197c-1200x700-jpg',
@@ -20,7 +36,7 @@ describe('mapSanityEntry', () => {
         'https://cdn.sanity.io/images/ciu31kkt/production/ca4484084823a781e6436bb5b7ab6c8164ab197c-1200x700.jpg',
       thumbnailSrc:
         'https://cdn.sanity.io/images/ciu31kkt/production/ca4484084823a781e6436bb5b7ab6c8164ab197c-1200x700.jpg',
-      altText: 'Some visually-descriptive text'
+      altText: ''
     })
   })
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [[DRAMS-1422](https://nacelle.atlassian.net/browse/DRAMS-1422)]

Sanity images do not include an `altText` field, and entries may not include an `altText` at the root level.
This can create situations where the preview connector will output `featuredMedia` with "altText": undefined` , which is not serializable JSON.

### WHAT is this pull request doing?

- if altText is not present, output as empty string which is consistent with `createMedia` method in the `@nacelle/client-js-sdk`
- updates the mockArticle to remove the `altText` and test for this absence in 'mapSanityEntry.test.ts'
