### PR TITLE
fix(ENG-2091): simplify exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nacelle/sanity-preview-connector",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nacelle/sanity-preview-connector",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@nacelle/client-js-sdk": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nacelle/sanity-preview-connector",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Preview unpublished Sanity content with the Nacelle Client JS SDK",
   "license": "ISC",
   "author": "Nacelle Inc. (getnacelle.com)",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,5 @@
-import NacelleSanityPreviewConnector, {
-  createSanityPreviewConnector,
-  CreateConnectorOptions,
-  NacelleSanityPreviewConnectorParams
-} from './connector/NacelleSanityPreviewConnector'
+import NacelleSanityPreviewConnector from './connector/NacelleSanityPreviewConnector'
+
+export * from './connector/NacelleSanityPreviewConnector'
 
 export default NacelleSanityPreviewConnector
-
-export {
-  createSanityPreviewConnector,
-  CreateConnectorOptions,
-  NacelleSanityPreviewConnectorParams
-}


### PR DESCRIPTION
Missed a commit with the last PR. This is a small clean-up to how we are exporting types, functions, and classes within the `NacelleSanityPreviewConnector` file.