### PR TITLE
fix(LD-1227): handle non reference sections

### DIFF
--- a/src/groq/sectionsProjection.ts
+++ b/src/groq/sectionsProjection.ts
@@ -2,9 +2,14 @@ import MediaProjection from './MediaProjection'
 
 export default (mediaProjection: string): string => {
   return `
-    sections[]->{
-      ...,
-      ${mediaProjection || MediaProjection}
+    sections[]{
+      ...@->{
+        ...,
+        ${mediaProjection || MediaProjection}
+      },
+      ...@{
+        ...
+      }
     }
   `
 }


### PR DESCRIPTION
Currently, all sections are treated as references when querying
```
import MediaProjection from './MediaProjection'

export default (mediaProjection: string): string => {
  return `
    sections[]->{
      ...,
      ${mediaProjection || MediaProjection}
    }
  `
}
```

This update ensures that we can handle sections that are not references
```
import MediaProjection from './MediaProjection'

export default (mediaProjection: string): string => {
  return `
    sections[]{
      ...@->{
        ...,
        ${mediaProjection || MediaProjection}
      },
      ...@{
        ...
      }
    }
  `
}

```