### PR TITLE
docs: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ The Client JS SDK uses connectors in the [`data` module](https://docs.getnacelle
 
 With this package we can update the `data` module so that by default it will fetch data directly from [Sanity's API](https://www.sanity.io/docs/api-cdn) using the [Sanity JavaScript client](https://www.sanity.io/docs/js-client). That way you can view edits and changes on Sanity without needing to re-index those updates with Nacelle.
 
+## NOTICE
+
+This package is deprecated. For up-to-date information about sourcing draft/preview content in frontend projects powered by Nacelle, please see [`docs.nacelle.com`](https://docs.nacelle.com/docs/preview-data).
+
 ## Usage
 
 ```js


### PR DESCRIPTION
## Why are these changes introduced?

Supports [ENG-9953](https://nacelle.atlassian.net/browse/ENG-9953)

> Deprecate dead-weight packages

## What is this pull request doing?

This PR adds a deprecation notice to the README, just in case the npm deprecation isn't noticed.

## Checklist

- [x] Updated the `README.md` with documentation changes (if applicable).

[ENG-9953]: https://nacelle.atlassian.net/browse/ENG-9953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ